### PR TITLE
Add errors and make response_type mandatory.

### DIFF
--- a/lib/errors/authorizationerror.js
+++ b/lib/errors/authorizationerror.js
@@ -1,0 +1,37 @@
+/**
+ * Module dependencies.
+ */
+var OAuth2Error = require('./oauth2error');
+
+/**
+ * `AuthorizationError` error.
+ *
+ * @api public
+ */
+function AuthorizationError(message, code, uri, status) {
+  if (!status) {
+    switch (code) {
+      case 'invalid_request': status = 400; break;
+      case 'unauthorized_client': status = 403; break;
+      case 'access_denied': status = 403; break;
+      case 'unsupported_response_type': status = 501; break;
+      case 'invalid_scope': status = 400; break;
+      case 'temporarily_unavailable': status = 503; break;
+    }
+  }
+  
+  OAuth2Error.call(this, message, code, uri, status);
+  Error.captureStackTrace(this, arguments.callee);
+  this.name = 'AuthorizationError';
+}
+
+/**
+ * Inherit from `OAuth2Error`.
+ */
+AuthorizationError.prototype.__proto__ = OAuth2Error.prototype;
+
+
+/**
+ * Expose `AuthorizationError`.
+ */
+module.exports = AuthorizationError;

--- a/lib/errors/oauth2error.js
+++ b/lib/errors/oauth2error.js
@@ -1,0 +1,23 @@
+/**
+ * `OAuth2Error` error.
+ *
+ * @api public
+ */
+function OAuth2Error(message, code, uri, status) {
+  Error.call(this);
+  this.message = message;
+  this.code = code || 'server_error';
+  this.uri = uri;
+  this.status = status || 500;
+}
+
+/**
+ * Inherit from `Error`.
+ */
+OAuth2Error.prototype.__proto__ = Error.prototype;
+
+
+/**
+ * Expose `OAuth2Error`.
+ */
+module.exports = OAuth2Error;

--- a/lib/errors/tokenerror.js
+++ b/lib/errors/tokenerror.js
@@ -1,0 +1,40 @@
+/**
+ * Module dependencies.
+ */
+var OAuth2Error = require('./oauth2error');
+
+/**
+ * `TokenError` error.
+ *
+ * @api public
+ */
+function TokenError(message, code, uri, status) {
+  if (!status) {
+    switch (code) {
+      case 'invalid_request': status = 400; break;
+      case 'invalid_client': status = 401; break;
+      case 'invalid_grant': status = 403; break;
+      case 'unauthorized_client': status = 403; break;
+      case 'unsupported_grant_type': status = 501; break;
+      case 'invalid_scope': status = 400; break;
+      case 'expired_token': status = 403; break;
+      case 'slow_down': status = 429; break;
+      case 'authorization_pending': status = 403; break;
+    }
+  }
+
+  OAuth2Error.call(this, message, code, uri, status);
+  Error.captureStackTrace(this, arguments.callee);
+  this.name = 'TokenError';
+}
+
+/**
+ * Inherit from `OAuth2Error`.
+ */
+TokenError.prototype.__proto__ = OAuth2Error.prototype;
+
+
+/**
+ * Expose `TokenError`.
+ */
+module.exports = TokenError;

--- a/lib/exchange/deviceCode.js
+++ b/lib/exchange/deviceCode.js
@@ -1,3 +1,5 @@
+var TokenError = require('../errors/tokenerror');
+
 module.exports = function(options, issue) {
   if (typeof options == 'function') {
     issue = options;

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,3 +3,5 @@ exports.middleware.request = require('./middleware/request');
 
 exports.exchange = {};
 exports.exchange.deviceCode = require('./exchange/deviceCode');
+
+exports.TokenError = require('./errors/tokenerror');

--- a/lib/middleware/request.js
+++ b/lib/middleware/request.js
@@ -1,4 +1,6 @@
-var merge = require('utils-merge');
+var merge = require('utils-merge')
+  , AuthorizationError = require('../errors/authorizationerror')
+  , TokenError = require('../errors/tokenerror');
 
 
 // https://tools.ietf.org/html/draft-ietf-oauth-device-flow-03
@@ -33,11 +35,8 @@ module.exports = function(options, issue) {
       , type = req.body.response_type
       , scope = req.body.scope;
     
-    // TODO: Return with error if not used as oauth2orize grant
-    /*
+    // TODO: Make this optional to allow use as oauth2orize grant.
     if (!type) { return next(new TokenError('Missing required parameter: response_type', 'invalid_request')); }
-    */
-    if (!type) { return next(); }
       
     if (scope) {
       for (var i = 0, len = separators.length; i < len; i++) {


### PR DESCRIPTION
Includes the device specific `(403) authorization_pending`, `(429) slow_down`, and `(403) expired_token` errors.
