### PR TITLE
Fixing utils not defined reference error in device code exchange

### DIFF
--- a/lib/exchange/deviceCode.js
+++ b/lib/exchange/deviceCode.js
@@ -1,4 +1,5 @@
-var TokenError = require('../errors/tokenerror');
+var merge = require('utils-merge'),
+    TokenError = require('../errors/tokenerror');
 
 module.exports = function(options, issue) {
   if (typeof options == 'function') {
@@ -31,7 +32,7 @@ module.exports = function(options, issue) {
       var tok = {};
       tok.access_token = accessToken;
       if (refreshToken) { tok.refresh_token = refreshToken; }
-      if (params) { utils.merge(tok, params); }
+      if (params) { merge(tok, params); }
       tok.token_type = tok.token_type || 'Bearer';
 
       var json = JSON.stringify(tok);


### PR DESCRIPTION
deviceCode.js does not import utils-merge. Hence the following error.

> ReferenceError: utils is not defined

I have fixed it updating the js file.