### PR TITLE
Remove response_type from authorization request.

### DIFF
--- a/lib/middleware/request.js
+++ b/lib/middleware/request.js
@@ -32,12 +32,8 @@ module.exports = function(options, issue) {
     // The 'user' property of `req` holds the authenticated user.  In the case
     // of the token endpoint, the property will contain the OAuth 2.0 client.
     var client = req[userProperty]
-      , type = req.body.response_type
       , scope = req.body.scope;
     
-    // TODO: Make this optional to allow use as oauth2orize grant.
-    if (!type) { return next(new TokenError('Missing required parameter: response_type', 'invalid_request')); }
-      
     if (scope) {
       for (var i = 0, len = separators.length; i < len; i++) {
         var separated = scope.split(separators[i]);

--- a/test/middleware/request.test.js
+++ b/test/middleware/request.test.js
@@ -15,13 +15,13 @@ describe('middleware.request', function() {
       function issue(client, scope, done) {
         if (client.id !== 's6BhdRkqt3') { return done(new Error('incorrect client argument')); }
         if (scope !== undefined) { return done(new Error('incorrect code argument')); }
-        return done(null, '74tq5miHKB', '94248', 'http://www.example.com/device');
+        return done(null, '74tq5miHKB', '94248');
       }
       
-      chai.connect.use(deviceAuthorizationRequest(issue))
+      chai.connect.use(deviceAuthorizationRequest({ verificationURI: 'http://www.example.com/device'}, issue))
         .req(function(req) {
           req.user = { id: 's6BhdRkqt3', name: 'Example' };
-          req.body = { response_type: 'device_code' };
+          req.body = {};
         })
         .end(function(res) {
           response = res;
@@ -52,13 +52,13 @@ describe('middleware.request', function() {
       function issue(client, scope, done) {
         if (client.id !== 's6BhdRkqt3') { return done(new Error('incorrect client argument')); }
         if (scope !== undefined) { return done(new Error('incorrect code argument')); }
-        return done(null, '74tq5miHKB', '94248', 'http://www.example.com/device', { interval: 5 });
+        return done(null, '74tq5miHKB', '94248', { interval: 5 });
       }
       
-      chai.connect.use(deviceAuthorizationRequest(issue))
+      chai.connect.use(deviceAuthorizationRequest({ verificationURI: 'http://www.example.com/device'}, issue))
         .req(function(req) {
           req.user = { id: 's6BhdRkqt3', name: 'Example' };
-          req.body = { response_type: 'device_code' };
+          req.body = {};
         })
         .end(function(res) {
           response = res;


### PR DESCRIPTION
Said parameter has been removed in newer versions of the draft specification (https://tools.ietf.org/html/draft-ietf-oauth-device-flow-06#appendix-B) - I presume the implication being that the server will respond to the device code exchange equivalently to an authorization code exchange (with OpenID Connect extension if desired).