### PR TITLE
Add activate grant.

### DIFF
--- a/lib/grant/activate.js
+++ b/lib/grant/activate.js
@@ -1,0 +1,120 @@
+/**
+ * Module dependencies.
+ */
+var AuthorizationError = require('../errors/authorizationerror');
+
+/**
+ * Handles requests for the user to authorize a grant by activating a requested device code.
+ *
+ * @param {Object} options
+ * @param {Function} activate
+ * @return {Object} module
+ * @api public
+ */
+module.exports = function activation(options, activate) {
+  if (typeof options == 'function') {
+    activate = options;
+    options = undefined;
+  }
+  options = options || {};
+  
+  if (!activate) { throw new TypeError('oauth2orize.device.activate grant requires an activate callback'); }
+  
+  var userCodeProperty   = options.userCodeProperty   || 'userCode';
+  var deviceCodeProperty = options.deviceCodeProperty || 'deviceCode';
+  
+  var inform = options.inform || function (txn, res, params, next) { return next(); }
+  
+  /* Parse authorization request implicit in device activation
+   *
+   * @param {http.ServerRequest} req
+   * @api public
+   */
+  function request(req) {
+    var userCode = req[userCodeProperty];
+    var clientID = userCode.clientID;
+      , scope = userCode.scope
+      , deviceCode = userCode[deviceCodeProperty];
+     
+    if (!clientID) { throw new AuthorizationError('Missing required parameter: client_id', 'invalid_request'); }
+    if (typeof clientID !== 'string') { throw new AuthorizationError('Invalid parameter: client_id must be a string', 'invalid_request'); }
+    
+    if (!deviceCode) { throw new AuthorizationError('Missing required information: deviceCode', 'invalid_request'); }
+    
+    if (scope) {
+      if (typeof scope !== 'string') {
+        throw new AuthorizationError('Invalid parameter: scope must be a string', 'invalid_request');
+      }
+
+      for (var i = 0, len = separators.length; i < len; i++) {
+        var separated = scope.split(separators[i]);
+        // only separate on the first matching separator.  this allows for a sort
+        // of separator "priority" (ie, favor spaces then fallback to commas)
+        if (separated.length > 1) {
+          scope = separated;
+          break;
+        }
+      }
+      
+      if (!Array.isArray(scope)) { scope = [ scope ]; }
+    }
+    
+    return {
+      clientID: clientID,
+      scope: scope,
+      deviceCode: deviceCode
+    };
+  }
+  
+  /* Activates the device code upon consent of user.
+   *
+   * @param {Object} txn
+   * @param {http.ServerResponse} res
+   * @param {Function} complete
+   * @param {Function} next
+   * @api public
+   */
+  function response(txn, res, complete, next) {
+    
+    if (!txn.res.allow) {
+      var params = { error: 'access_denied' };
+      return inform(txn, res, params, next);
+    }
+    
+    function activated(err) {
+      if (err) { return next(err); }
+      
+      var params = {};
+      complete(function(err) {
+        if (err) { return next(err); }
+        return inform(txn, res, params, next);
+      });
+    }
+    
+    try {
+      activate(txn.req.deviceCode, activated);
+    } catch (ex) {
+      return next(ex);
+    }
+  }
+  
+  function errorHandler(err, txn, res, next) {
+    var params = {};
+    
+    params.error = err.code || 'server_error';
+    if (err.message) { params.error_description = err.message; }
+    if (err.uri) { params.error_uri = err.uri; }
+    
+    return inform(txn, res, params, next);
+  }
+  
+  /**
+   * Return `user code` activation module.
+   */
+  var mod = {};
+  mod.name = 'activate';
+  mod.request = request;
+  mod.response = response;
+  mod.error = errorHandler;
+  return mod;
+}

--- a/lib/grant/activate.js
+++ b/lib/grant/activate.js
@@ -20,9 +20,7 @@ module.exports = function activation(options, activate) {
   
   if (!activate) { throw new TypeError('oauth2orize.device.activate grant requires an activate callback'); }
   
-  var userCodeProperty   = options.userCodeProperty   || 'userCode';
-  var deviceCodeProperty = options.deviceCodeProperty || 'deviceCode';
-  
+  var userCodeProperty = options.userCodeProperty || 'user_code';
   var inform = options.inform || function (txn, res, params, next) { return next(); }
   
   /* Parse authorization request implicit in device activation
@@ -32,32 +30,14 @@ module.exports = function activation(options, activate) {
    */
   function request(req) {
     var userCode = req[userCodeProperty];
-    var clientID = userCode.clientID;
+    var clientID = userCode.client_id
       , scope = userCode.scope
-      , deviceCode = userCode[deviceCodeProperty];
+      , deviceCode = userCode.device_code;
      
     if (!clientID) { throw new AuthorizationError('Missing required parameter: client_id', 'invalid_request'); }
     if (typeof clientID !== 'string') { throw new AuthorizationError('Invalid parameter: client_id must be a string', 'invalid_request'); }
     
-    if (!deviceCode) { throw new AuthorizationError('Missing required information: deviceCode', 'invalid_request'); }
-    
-    if (scope) {
-      if (typeof scope !== 'string') {
-        throw new AuthorizationError('Invalid parameter: scope must be a string', 'invalid_request');
-      }
-
-      for (var i = 0, len = separators.length; i < len; i++) {
-        var separated = scope.split(separators[i]);
-        // only separate on the first matching separator.  this allows for a sort
-        // of separator "priority" (ie, favor spaces then fallback to commas)
-        if (separated.length > 1) {
-          scope = separated;
-          break;
-        }
-      }
-      
-      if (!Array.isArray(scope)) { scope = [ scope ]; }
-    }
+    if (!deviceCode) { throw new AuthorizationError('Missing required parameter: device_code', 'invalid_request'); }
     
     return {
       clientID: clientID,
@@ -90,7 +70,7 @@ module.exports = function activation(options, activate) {
         return inform(txn, res, params, next);
       });
     }
-    
+
     try {
       activate(txn.req.deviceCode, activated);
     } catch (ex) {

--- a/lib/grant/activate.js
+++ b/lib/grant/activate.js
@@ -72,7 +72,12 @@ module.exports = function activation(options, activate) {
     }
 
     try {
-      activate(txn.req.deviceCode, activated);
+      var arity = activate.length;
+      if (arity == 3) {
+        activate(txn.req.deviceCode, txn, activated);
+      } else { // arity == 2
+        activate(txn.req.deviceCode, activated);
+      }
     } catch (ex) {
       return next(ex);
     }

--- a/lib/grant/activate.js
+++ b/lib/grant/activate.js
@@ -20,31 +20,7 @@ module.exports = function activation(options, activate) {
   
   if (!activate) { throw new TypeError('oauth2orize.device.activate grant requires an activate callback'); }
   
-  var userCodeProperty = options.userCodeProperty || 'user_code';
   var inform = options.inform || function (txn, res, params, next) { return next(); }
-  
-  /* Parse authorization request implicit in device activation
-   *
-   * @param {http.ServerRequest} req
-   * @api public
-   */
-  function request(req) {
-    var userCode = req[userCodeProperty];
-    var clientID = userCode.client_id
-      , scope = userCode.scope
-      , deviceCode = userCode.device_code;
-     
-    if (!clientID) { throw new AuthorizationError('Missing required parameter: client_id', 'invalid_request'); }
-    if (typeof clientID !== 'string') { throw new AuthorizationError('Invalid parameter: client_id must be a string', 'invalid_request'); }
-    
-    if (!deviceCode) { throw new AuthorizationError('Missing required parameter: device_code', 'invalid_request'); }
-    
-    return {
-      clientID: clientID,
-      scope: scope,
-      deviceCode: deviceCode
-    };
-  }
   
   /* Activates the device code upon consent of user.
    *
@@ -98,7 +74,6 @@ module.exports = function activation(options, activate) {
    */
   var mod = {};
   mod.name = 'activate';
-  mod.request = request;
   mod.response = response;
   mod.error = errorHandler;
   return mod;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,9 @@
 exports.middleware = {};
 exports.middleware.request = require('./middleware/request');
 
+exports.grant = {};
+exports.grant.activate = require('./grant/activate');
+
 exports.exchange = {};
 exports.exchange.deviceCode = require('./exchange/deviceCode');
 

--- a/lib/middleware/transactionLoader.js
+++ b/lib/middleware/transactionLoader.js
@@ -1,0 +1,83 @@
+/**
+ * Loads an OAuth 2.0 device code authorization transaction.
+ *
+ * This middleware is used to load a pending OAuth 2.0 device code transaction
+ * serialized after a request to the device code grant endpoint.
+ *
+ * Options:
+ *
+ *     scopeSeparator  if scope is stored as string, indicates the character separating the individual scopes
+ *     txnProperty     key under which transaction information is stored on the req object
+ *     extendTxn       optional callback function to allow extending the transaction object
+ *
+ * @param {Server} server
+ * @param {Object} options
+ * @return {Function}
+ * @api protected
+ */
+module.exports = function (server, options) {
+  options = options || {};
+  
+  if (!server) { throw new TypeError('oauth2orize.transactionLoader middleware requires a server argument'); }
+  
+  var separators = options.scopeSeparator || ' ';
+  if (!Array.isArray(separators)) {
+    separators = [ separators ];
+  }
+  
+  var txnProperty = options.txnProperty || 'txn';
+  
+  return function transactionLoader(req, res, next) {
+    if (req.oauth2) { return next(); }
+    
+    var txn = req[txnProperty];
+    if (typeof txn !== 'object') { return next(new Error('Invalid transaction configuration')); }
+    
+    req.oauth2 = {};
+    req.oauth2.client = txn.client;
+    req.oauth2.user = txn.user || req.user;
+    
+    var scope = txn.scope;
+    if (scope && typeof scope === 'string') {
+      for (var i = 0, len = separators.length; i < len; i++) {
+        var separated = scope.split(separators[i]);
+        // only separate on the first matching separator.  this allows for a sort
+        // of separator "priority" (ie, favor spaces then fallback to commas)
+        if (separated.length > 1) {
+          scope = separated;
+          break;
+        }
+      }
+      
+      if (!Array.isArray(scope)) { scope = [ scope ]; }
+    }
+    
+    req.oauth2.req = {};
+    req.oauth2.req.type = 'activate';
+    req.oauth2.req.scope = scope;
+    
+    var params = Object.keys(txn);
+    for (param in params) {
+      if ([ 'client', 'user', 'scope' ].indexOf(param) === -1) { continue; }
+      req.oauth2.req[param] = txn[param];
+    }
+    
+    if (res.locals) {
+      req.oauth2.locals = res.locals;
+    }
+    
+    if (options.extendTxn && typeof options.extendTxn === 'function') {
+      
+      function post(err, mod) {
+        if (err) { return next(err); }
+        if (mod) { req.oauth2 = mod; }
+
+        return next();
+      }
+      
+      return options.extendTxn(req.oauth2, post);
+    }
+    
+    return next();
+  };
+};

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   ],
   "main": "./lib",
   "dependencies": {
+    "chai-oauth2orize-grant": "^0.3.0",
     "utils-merge": "^1.0.0"
   },
   "devDependencies": {

--- a/test/bootstrap/node.js
+++ b/test/bootstrap/node.js
@@ -1,5 +1,6 @@
 var chai = require('chai');
 
 chai.use(require('chai-connect-middleware'));
+chai.use(require('chai-oauth2orize-grant'));
 
 global.expect = chai.expect;

--- a/test/grant/activate.test.js
+++ b/test/grant/activate.test.js
@@ -1,0 +1,381 @@
+var chai = require('chai')
+  , activation = require('../../lib/grant/activate')
+  , AuthorizationError = require('../../lib/errors/authorizationerror');
+
+describe('grant.activate', function() {
+  
+  describe('module', function() {
+    var mod = activation(function(){});
+    
+    it('should be named activate', function() {
+      expect(mod.name).to.equal('activate');
+    });
+    
+    it('should expose request and response functions', function() {
+      expect(mod.request).to.be.a('function');
+      expect(mod.response).to.be.a('function');
+    });
+  });
+  
+  it('should throw if constructed without an activate callback', function() {
+    expect(function() {
+      activation();
+    }).to.throw(TypeError, 'oauth2orize.device.activate grant requires an activate callback');
+  });
+
+  describe('request parsing', function() {
+    function issue(){}
+    
+    describe('request', function() {
+      var err, out;
+      
+      before(function(done) {
+        chai.oauth2orize.grant(activation(issue))
+          .req(function(req) {
+            req.user_code = {};
+            req.user_code.client_id   = 'c123';
+            req.user_code.scope       = [ 'read' ];
+            req.user_code.device_code = 'dc123';
+          })
+          .parse(function(e, o) {
+            err = e;
+            out = o;
+            done();
+          })
+          .authorize();
+      });
+      
+      it('should not error', function() {
+        expect(err).to.be.null;
+      });
+      
+      it('should parse request', function() {
+        expect(out.clientID).to.equal('c123');
+        expect(out.scope).to.be.an('array');
+        expect(out.scope).to.have.length(1);
+        expect(out.scope[0]).to.equal('read');
+        expect(out.deviceCode).to.equal('dc123');
+      });
+    });
+     
+    describe('request with missing client_id parameter', function() {
+      var err, out;
+      
+      before(function(done) {
+        chai.oauth2orize.grant(activation(issue))
+          .req(function(req) {
+            req.user_code = {};
+            req.user_code.scope       = [ 'read' ];
+            req.user_code.device_code = 'dc123';
+          })
+          .parse(function(e, o) {
+            err = e;
+            out = o;
+            done();
+          })
+          .authorize();
+      });
+      
+      it('should error', function() {
+        expect(err).to.be.an.instanceOf(Error);
+        expect(err.constructor.name).to.equal('AuthorizationError');
+        expect(err.message).to.equal('Missing required parameter: client_id');
+        expect(err.code).to.equal('invalid_request');
+      });
+    });
+
+    describe('request with invalid client_id parameter', function() {
+      var err, out;
+      
+      before(function(done) {
+        chai.oauth2orize.grant(activation(issue))
+          .req(function(req) {
+            req.user_code = {};
+            req.user_code.client_id   = ['c123', 'c123'];
+            req.user_code.scope       = [ 'read' ];
+            req.user_code.device_code = 'dc123';
+          })
+          .parse(function(e, o) {
+            err = e;
+            out = o;
+            done();
+          })
+          .authorize();
+      });
+      
+      it('should error', function() {
+        expect(err).to.be.an.instanceOf(Error);
+        expect(err.constructor.name).to.equal('AuthorizationError');
+        expect(err.message).to.equal('Invalid parameter: client_id must be a string');
+        expect(err.code).to.equal('invalid_request');
+      });
+    });
+    
+    describe('request with missing device_code parameter', function() {
+      var err, out;
+      
+      before(function(done) {
+        chai.oauth2orize.grant(activation(issue))
+          .req(function(req) {
+            req.user_code = {};
+            req.user_code.client_id = 'c123';
+            req.user_code.scope     = [ 'read' ];
+          })
+          .parse(function(e, o) {
+            err = e;
+            out = o;
+            done();
+          })
+          .authorize();
+      });
+      
+      it('should error', function() {
+        expect(err).to.be.an.instanceOf(Error);
+        expect(err.constructor.name).to.equal('AuthorizationError');
+        expect(err.message).to.equal('Missing required parameter: device_code');
+        expect(err.code).to.equal('invalid_request');
+      });
+    });
+  });
+
+  describe('decision handling', function() {
+    
+    describe('transaction', function() {
+      var response;
+      
+      before(function(done) {
+        function activate(deviceCode, done) {
+          if (deviceCode !== 'dc123') { return done(new Error('incorrect deviceCode argument')); }
+          
+          return done(null);
+        }
+        
+        function inform(txn, res, params) {
+          res.end('User ' + txn.user.name + ' has authorized client ' + txn.client.name + '.');
+        }
+        
+        chai.oauth2orize.grant(activation({ inform: inform }, activate))
+          .txn(function(txn) {
+            txn.client = { id: 'c123', name: 'Example' };
+            txn.req = {
+              clientID:   'c123',
+              deviceCode: 'dc123'
+            };
+            txn.user = { id: 'u123', name: 'Bob' };
+            txn.res = { allow: true };
+          })
+          .end(function(res) {
+            response = res;
+            done();
+          })
+          .decide();
+      });
+      
+      it('should respond', function() {
+        expect(response.statusCode).to.equal(200);
+        expect(response.body).to.equal('User Bob has authorized client Example.');
+      });
+    });
+
+    describe('transaction with complete callback', function() {
+      var response, completed;
+      
+      before(function(done) {
+        function activate(deviceCode, done) {
+          if (deviceCode !== 'dc123') { return done(new Error('incorrect deviceCode argument')); }
+          
+          return done(null);
+        }
+        
+        function inform(txn, res, params) {
+          res.end('User ' + txn.user.name + ' has authorized client ' + txn.client.name + '.');
+        }
+        
+        chai.oauth2orize.grant(activation({ inform: inform }, activate))
+          .txn(function(txn) {
+            txn.client = { id: 'c123', name: 'Example' };
+            txn.req = {
+              clientID:   'c123',
+              deviceCode: 'dc123'
+            };
+            txn.user = { id: 'u123', name: 'Bob' };
+            txn.res = { allow: true };
+          })
+          .end(function(res) {
+            response = res;
+            done();
+          })
+          .decide(function(cb) {
+            completed = true;
+            process.nextTick(function() { cb() });
+          });
+      });
+
+      it('should call complete callback', function() {
+        expect(completed).to.be.true;
+      });
+      
+      it('should respond', function() {
+        expect(response.statusCode).to.equal(200);
+        expect(response.body).to.equal('User Bob has authorized client Example.');
+      });
+    });
+
+    describe('transaction without inform callback', function() {
+      var passed;
+      
+      before(function(done) {
+        function activate(deviceCode, done) {
+          if (deviceCode !== 'dc123') { return done(new Error('incorrect deviceCode argument')); }
+          
+          return done(null);
+        }
+        
+        chai.oauth2orize.grant(activation(activate))
+          .txn(function(txn) {
+            txn.client = { id: 'c123', name: 'Example' };
+            txn.req = {
+              clientID:   'c123',
+              deviceCode: 'dc123'
+            };
+            txn.user = { id: 'u123', name: 'Bob' };
+            txn.res = { allow: true };
+          })
+          .next(function(req, res, next) {
+            passed = true;
+            done();
+          })
+          .decide();
+      });
+      
+      it('should pass back up to the middleware processing', function() {
+        expect(passed).to.equal(true);
+      });
+    });
+    
+    describe('encountering an error while activating device code', function() {
+      var err;
+      
+      before(function(done) {
+        function activate(deviceCode, done) {
+          return done(new Error('something went wrong'));
+        }
+        
+        chai.oauth2orize.grant(activation(activate))
+          .txn(function(txn) {
+            txn.client = { id: 'cERROR', name: 'Example' };
+            txn.req = {
+              clientID:   'c123',
+              deviceCode: 'dc123'
+            };
+            txn.user = { id: 'u123', name: 'Bob' };
+            txn.res = { allow: true };
+          })
+          .next(function(e) {
+            err = e;
+            done();
+          })
+          .decide();
+      });
+      
+      it('should error', function() {
+        expect(err).to.be.an.instanceOf(Error);
+        expect(err.message).to.equal('something went wrong');
+      });
+    });
+
+    describe('throwing an error while activating device code', function() {
+      var err;
+      
+      before(function(done) {
+        function activate(deviceCode, done) {
+          throw new Error('something was thrown');
+        }
+        
+        chai.oauth2orize.grant(activation(activate))
+          .txn(function(txn) {
+            txn.client = { id: 'cTHROW', name: 'Example' };
+            txn.req = {
+              clientID:   'c123',
+              deviceCode: 'dc123'
+            };
+            txn.user = { id: 'u123', name: 'Bob' };
+            txn.res = { allow: true };
+          })
+          .next(function(e) {
+            err = e;
+            done();
+          })
+          .decide();
+      });
+      
+      it('should error', function() {
+        expect(err).to.be.an.instanceOf(Error);
+        expect(err.message).to.equal('something was thrown');
+      });
+    });
+  });
+
+  describe('error handling', function() {
+    
+    describe('error on transaction', function() {
+      var response;
+      
+      before(function(done) {
+        function activate(deviceCode, done) {}
+        
+        function inform(txn, res, params) {
+          res.end('code: ' + params.error + ', message: ' + params.error_description);
+        }
+        
+        chai.oauth2orize.grant(activation({ inform: inform }, activate))
+          .txn(function(txn) {
+            txn.client = { id: 'c123', name: 'Example' };
+            txn.req = {
+              clientID:   'c123',
+              deviceCode: 'dc123'
+            };
+            txn.user = { id: 'u123', name: 'Bob' };
+            txn.res = { allow: true };
+          })
+          .end(function(res) {
+            response = res;
+            done();
+          })
+          .error(new Error('something went wrong'));
+      });
+      
+      it('should respond', function() {
+        expect(response.body).to.equal('code: server_error, message: something went wrong');
+      });
+    });
+
+    describe('error on transaction without inform callback', function() {
+      var passed;
+      
+      before(function(done) {
+        function activate(deviceCode, done) {}
+        
+        chai.oauth2orize.grant(activation(activate))
+          .txn(function(txn) {
+            txn.client = { id: 'c123', name: 'Example' };
+            txn.req = {
+              clientID:   'c123',
+              deviceCode: 'dc123'
+            };
+            txn.user = { id: 'u123', name: 'Bob' };
+            txn.res = { allow: true };
+          })
+          .next(function(err, req, res, next) {
+            passed = true;
+            done();
+          })
+          .error(new Error('something went wrong'));
+      });
+      
+      it('should pass back up to the middleware processing', function() {
+        expect(passed).to.equal(true);
+      });
+    });
+  });
+});


### PR DESCRIPTION
To be used by `oauth2orize` for calls to the verificationURI. It takes an `activate` callback instead of  an `issue` callback, and uses an `inform` function instead of a `response_mode`. 

So, e.g., on the activation endpoint you have a middleware chain that looks like:

```js
[ function(req, res, next) {
  db.findByUserCode(req.body.code, function(err, record) {
    if (err) { return next(err); }
    req.body.response_type = 'activate';
    req.user_code = record;
    next();  
  });
}, server.authorization(validate, immediate) ]
```

which will then call out to an activate callback with definition one of

```js
function activate(deviceCode, txn, done) {}
function activate(deviceCode, done) {}
```

and you can also configure an inform function with definition

```js
function inform(txn, res, params, next) {}
```

to give the user information as to the success or failure of the flow. Either calling `next()` or not providing an `inform` function will cause `oauth2orize` to pass back up to `express` after activating the device code.